### PR TITLE
従業員詳細の給料表記をカンマ区切りに修正

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -168,7 +168,7 @@
                   <tr>
                     <th nowrap>給料</th>
                     <td>
-                      <span th:utext="${employee.salary + '円'}">400000円</span>
+                      <span th:utext="${#numbers.formatInteger(employee.salary, 2, 'COMMA') + '円'}">400000円</span>
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
Thymeleafの#numbers.formatIntegerを使って表記を修正しました。